### PR TITLE
Try importing from v2, fallback on v1_1

### DIFF
--- a/rax_default_network_flags_python_novaclient_ext/__init__.py
+++ b/rax_default_network_flags_python_novaclient_ext/__init__.py
@@ -17,9 +17,14 @@
 Instance create default networks extension
 """
 from novaclient import utils
-from novaclient.v1_1 import servers
-from novaclient.v1_1 import shell
 from novaclient.openstack.common import cliutils
+
+try:
+    from novaclient.v2 import servers
+    from novaclient.v2 import shell
+except ImportError:
+    from novaclient.v1_1 import servers
+    from novaclient.v1_1 import shell
 
 
 def add_args():


### PR DESCRIPTION
Release 2.21.0 of python-novaclient deprecates the v1_1 module. This
commit prevents a warning message from being displayed when running
the latest version of python-novaclient.